### PR TITLE
docs: add readme for `node-secrets` and `node-security`

### DIFF
--- a/node/secrets/README.md
+++ b/node/secrets/README.md
@@ -1,0 +1,2 @@
+# Node Secrets [![Docker Pulls](https://img.shields.io/docker/pulls/studiondev/node-secrets)](https://hub.docker.com/r/studiondev/node-secrets)
+## Node.js Docker image based on the `cimg/node` with the addition of Infisical secret manager

--- a/node/security/README.md
+++ b/node/security/README.md
@@ -1,0 +1,2 @@
+# Node Security [![Docker Pulls](https://img.shields.io/docker/pulls/studiondev/node-security)](https://hub.docker.com/r/studiondev/node-security)
+## Node.js Docker image based on the `studiondev/node-secrets` with the addition of security tools, Gitleaks, Trivy, and Semgrep


### PR DESCRIPTION
The initial minimalistic version with a short description and counter for docker pulls.