### PR TITLE
feat: `node-secrets` 18.20.7, 20.19.0, 22.14.0

### DIFF
--- a/node/secrets/18/Dockerfile
+++ b/node/secrets/18/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:18.20.4
+FROM cimg/node:18.20.7
 
 # Copy directly from the image to avoid using insecure curl
-COPY --from=infisical/cli:0.31.4 /bin/infisical /usr/local/bin/infisical
+COPY --from=infisical/cli:0.31.9 /bin/infisical /usr/local/bin/infisical

--- a/node/secrets/20/Dockerfile
+++ b/node/secrets/20/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:20.18.0
+FROM cimg/node:20.19.0
 
 # Copy directly from the image to avoid using insecure curl
-COPY --from=infisical/cli:0.31.4 /bin/infisical /usr/local/bin/infisical
+COPY --from=infisical/cli:0.31.9 /bin/infisical /usr/local/bin/infisical

--- a/node/secrets/22/Dockerfile
+++ b/node/secrets/22/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/node:22.10.0
+FROM cimg/node:22.14.0
 
 # Copy directly from the image to avoid using insecure curl
-COPY --from=infisical/cli:0.31.4 /bin/infisical /usr/local/bin/infisical
+COPY --from=infisical/cli:0.31.9 /bin/infisical /usr/local/bin/infisical


### PR DESCRIPTION
Bumps `infisical` to 0.31.9 for all versions.