### PR TITLE
feat: `node-security` 18.20.7, 20.19.0, 22.14.0

### DIFF
--- a/node/security/18/Dockerfile
+++ b/node/security/18/Dockerfile
@@ -1,7 +1,7 @@
-FROM studiondev/node-secrets:18.20.4
+FROM studiondev/node-secrets:18.20.7
 
 # Copy executables directly from images to avoid using insecure curl
-COPY --from=zricethezav/gitleaks:v8.21.1 /usr/bin/gitleaks /usr/local/bin/gitleaks
+COPY --from=zricethezav/gitleaks:v8.21.4 /usr/bin/gitleaks /usr/local/bin/gitleaks
 COPY --from=aquasec/trivy:0.56.2 /usr/local/bin/trivy /usr/local/bin/trivy
 
 # Install Semgrep explicitly, since coping from the image won't work due to Python bindings

--- a/node/security/20/Dockerfile
+++ b/node/security/20/Dockerfile
@@ -1,10 +1,10 @@
-FROM studiondev/node-secrets:20.18.0
+FROM studiondev/node-secrets:20.19.0
 
 # Copy executables directly from images to avoid using insecure curl
-COPY --from=zricethezav/gitleaks:v8.21.1 /usr/bin/gitleaks /usr/local/bin/gitleaks
+COPY --from=zricethezav/gitleaks:v8.24.0 /usr/bin/gitleaks /usr/local/bin/gitleaks
 COPY --from=aquasec/trivy:0.56.2 /usr/local/bin/trivy /usr/local/bin/trivy
 
 # Install Semgrep explicitly, since coping from the image won't work due to Python bindings
 RUN sudo apt update
 RUN sudo apt install -y python3 python3-pip
-RUN sudo pip3 install semgrep==1.93.0
+RUN sudo pip3 install semgrep==1.114.0

--- a/node/security/22/Dockerfile
+++ b/node/security/22/Dockerfile
@@ -1,10 +1,10 @@
-FROM studiondev/node-secrets:22.10.0
+FROM studiondev/node-secrets:22.14.0
 
 # Copy executables directly from images to avoid using insecure curl
-COPY --from=zricethezav/gitleaks:v8.21.1 /usr/bin/gitleaks /usr/local/bin/gitleaks
+COPY --from=zricethezav/gitleaks:v8.24.0 /usr/bin/gitleaks /usr/local/bin/gitleaks
 COPY --from=aquasec/trivy:0.56.2 /usr/local/bin/trivy /usr/local/bin/trivy
 
 # Install Semgrep explicitly, since coping from the image won't work due to Python bindings
 RUN sudo apt update
 RUN sudo apt install -y python3 python3-pip
-RUN sudo pip3 install semgrep==1.93.0
+RUN sudo pip3 install semgrep==1.114.0


### PR DESCRIPTION
For node 18, bumps `gitleaks` to v8.21.4
For node 20 and 22, bumps `gitleaks` to v8.24.0, `semgrep` to `1.114.0`