### PR TITLE
fix: append lts tag to the list of build args

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -18,7 +18,7 @@ for tag in "${IMAGE_TAGS[@]}"; do
 done
 
 if [[ "${NODE_VERSION}" = "${LTS_VERSION}" ]]; then
-  DOCKER_BUILD_ARGS=("--tag=${IMAGE_NAME}:lts")
+  DOCKER_BUILD_ARGS+=("--tag=${IMAGE_NAME}:lts")
 fi
 
 DOCKER_BUILD_ARGS+=("${DOCKERFILE_DIR}")


### PR DESCRIPTION
Previously the lts tag would override build args by assigning instead of appending which would result in failure to scan and push the image.