### PR TITLE
docs: list actual commands in the usage examples

### DIFF
--- a/node/secrets/README.md
+++ b/node/secrets/README.md
@@ -16,6 +16,6 @@ Example usage in CircleCI as a Docker executor:
     steps:
       - checkout
       - run: |
-          node -v
-          infisical -v
+          node --version
+          infisical --version
 ```

--- a/node/security/README.md
+++ b/node/security/README.md
@@ -20,9 +20,11 @@ Example usage in CircleCI as a Docker executor:
     steps:
       - checkout
       - run: |
-          node -v
-          infisical -v
-          gitleaks -v
-          trivy -v
-          semgrep -v
+          node --version
+          infisical --version
+          gitleaks --version
+          grype --version
+          semgrep --version
+          syft --version
+          trivy --version
 ```


### PR DESCRIPTION
Use `--version` instead of `-v`.
Add grype and syft to the security usage example.