### PR TITLE
fix: install Semgrep in isolated environment

### DIFF
--- a/node/security/Dockerfile.template
+++ b/node/security/Dockerfile.template
@@ -10,7 +10,9 @@ COPY --from=anchore/syft:${SYFT_VERSION} /syft /usr/local/bin/syft
 COPY --from=aquasec/trivy:${TRIVY_VERSION} /usr/local/bin/trivy /usr/local/bin/trivy
 
 # Install Semgrep explicitly, since coping from the image won't work due to Python bindings
-RUN apt update && apt install -y python3 python3-pip
-RUN pip3 install semgrep==${SEMGREP_VERSION}
+ENV PY_VENV_PATH=/opt/py/venv
+ENV PATH="${PY_VENV_PATH}/bin:${PATH}"
+RUN apt update && apt install -y python3 python3-pip python3-venv
+RUN python3 -m venv ${PY_VENV_PATH} && pip3 install semgrep==${SEMGREP_VERSION}
 
 USER circleci


### PR DESCRIPTION
Set up a virtual environment using Python's `venv` module to ensure `pip` packages are isolated from system-wide packages, in compliance with externally manager environments (PEP 668).