### PR TITLE
feat: auto update even Node.js versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ trunk-filters: &trunk-filters
 
 orbs:
   continuation: circleci/continuation@1.1.0
+  github-cli: circleci/github-cli@3.0.0
   security: studion/security@2.1.0
   shellcheck: circleci/shellcheck@3.4.0
 
@@ -20,6 +21,43 @@ jobs:
     steps:
       - checkout
       - security/scan_dockerfile
+  validate-automation:
+    docker:
+      - image: cimg/node:lts
+    steps:
+      - checkout
+      - run:
+          name: Validate update automation
+          command: ./scripts/updates/validate.sh
+  update-node-env-files:
+    docker:
+      - image: cimg/node:lts
+    environment:
+      DISCOVERY_REPORT_PATH: /tmp/node-update-discovery.json
+    steps:
+      - checkout
+      - github-cli/setup:
+          auth_method: app
+      - run:
+          name: Configure Git author
+          command: |
+            git config user.name "studion-images[bot]"
+            git config user.email "4314765+studion-images[bot]@users.noreply.github.com"
+      - run:
+          name: Discover and apply Node updates
+          command: ./scripts/updates/discover-node-updates.js --apply
+      - run:
+          name: Create or update node-secrets PR
+          command: ./scripts/updates/publish-node-updates-pr.sh secrets
+      - run:
+          name: Create or update node-security PR
+          command: ./scripts/updates/publish-node-updates-pr.sh security
+      - run:
+          name: Update node-security dependency gate
+          command: ./scripts/updates/update-security-pr-gate.sh
+      - store_artifacts:
+          path: /tmp/node-update-discovery.json
+          destination: node-update-discovery.json
   detect-image-changes:
     executor: continuation/default
     steps:
@@ -34,13 +72,23 @@ jobs:
           configuration_path: .circleci/push-image.yml
 
 workflows:
+  weekly-node-updates:
+    triggers:
+      - schedule:
+          cron: "0 9 * * 1"
+          filters: *trunk-filters
+    jobs:
+      - update-node-env-files
   scan-and-detect:
     jobs:
       - shellcheck/check:
+          external_sources: true
           filters: *change-filters
       - scan-dockerfile:
           filters: *change-filters
       - security/detect_secrets_git:
+          filters: *change-filters
+      - validate-automation:
           filters: *change-filters
       - security/detect_secrets_dir:
           filters: *trunk-filters
@@ -51,3 +99,4 @@ workflows:
             - scan-dockerfile
             - security/detect_secrets_git
             - security/detect_secrets_dir
+            - validate-automation

--- a/.circleci/push-image.yml
+++ b/.circleci/push-image.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  github-cli: circleci/github-cli@3.0.0
   security: studion/security@2.1.0
 
 commands:
@@ -45,10 +46,23 @@ jobs:
           name: Push image
           command: docker image push -a "${IMAGE_NAME}"
 
+  update-security-pr-gate:
+    docker:
+      - image: cimg/node:lts
+    steps:
+      - checkout
+      - github-cli/setup:
+          auth_method: app
+      - run:
+          name: Update node-security dependency gate
+          command: ./scripts/updates/update-security-pr-gate.sh
+
 workflows:
   push-image-to-hub:
     jobs:
       - write-build-push:
           matrix:
+            alias: write-build-push
             parameters:
               env_file_path: []
+      - update-security-pr-gate

--- a/scripts/detect-image-changes.sh
+++ b/scripts/detect-image-changes.sh
@@ -2,10 +2,10 @@
 
 CONTINUE_CONFIG_PATH=".circleci/push-image.yml"
 CHANGES_PARAM_KEY=".workflows.push-image-to-hub.jobs[0].write-build-push.matrix.parameters.env_file_path"
-DIFF_JSON_ARR=$(git diff --name-only --diff-filter=AM HEAD~1 \
-  | grep -E '^node/(secrets|security)/[0-9]+$' \
-  | jq -R -c -s 'split("\n")[:-1]')
-
+GATE_REQUIRES_KEY=".workflows.push-image-to-hub.jobs[1].update-security-pr-gate.requires"
+DIFF_JSON_ARR=$(git diff --name-only --diff-filter=AM HEAD~1 |
+  grep -E '^node/(secrets|security)/[0-9]+$' |
+  jq -R -c -s 'split("\n")[:-1]')
 
 if [[ "${DIFF_JSON_ARR}" = "[]" ]]; then
   echo "No image changes detected. Nothing to update."
@@ -23,5 +23,6 @@ fi
 echo "Detected image changes: ${DIFF_JSON_ARR}"
 
 yq "${CHANGES_PARAM_KEY}=${DIFF_JSON_ARR}" -i "${CONTINUE_CONFIG_PATH}"
+yq "${GATE_REQUIRES_KEY}=[\"write-build-push\"]" -i "${CONTINUE_CONFIG_PATH}"
 
-echo "Updated ${CONTINUE_CONFIG_PATH} with image changes";
+echo "Updated ${CONTINUE_CONFIG_PATH} with image changes"

--- a/scripts/updates/discover-node-updates.js
+++ b/scripts/updates/discover-node-updates.js
@@ -1,0 +1,561 @@
+#!/usr/bin/env node
+
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+const config = {
+  nodeReleaseIndexPath: process.env.NODE_RELEASE_INDEX_PATH ?? "",
+  nodeReleaseIndexUrl:
+    process.env.NODE_RELEASE_INDEX_URL ??
+    "https://nodejs.org/download/release/index.json",
+  dockerHubApiUrl:
+    process.env.DOCKER_HUB_API_URL ?? "https://hub.docker.com/v2/repositories",
+  pypiApiUrl: process.env.PYPI_API_URL ?? "https://pypi.org/pypi",
+  dockerTagPageSize: Number(process.env.DOCKER_TAG_PAGE_SIZE ?? 100),
+  maxDockerTagPages: Number(process.env.MAX_DOCKER_TAG_PAGES ?? 5),
+  discoveryReportPath: process.env.DISCOVERY_REPORT_PATH ?? "",
+};
+
+const images = {
+  secrets: {
+    dir: "node/secrets",
+    variables: ["NODE_VERSION", "INFISICAL_VERSION", "IMAGE_TAGS"],
+    tools: ["INFISICAL_VERSION"],
+  },
+  security: {
+    dir: "node/security",
+    variables: [
+      "NODE_VERSION",
+      "GITLEAKS_VERSION",
+      "GRYPE_VERSION",
+      "SEMGREP_VERSION",
+      "SYFT_VERSION",
+      "TRIVY_VERSION",
+      "IMAGE_TAGS",
+    ],
+    tools: [
+      "GITLEAKS_VERSION",
+      "GRYPE_VERSION",
+      "SEMGREP_VERSION",
+      "SYFT_VERSION",
+      "TRIVY_VERSION",
+    ],
+  },
+};
+
+const toolSources = {
+  INFISICAL_VERSION: { type: "docker", name: "infisical/cli" },
+  GITLEAKS_VERSION: { type: "docker", name: "zricethezav/gitleaks" },
+  GRYPE_VERSION: { type: "docker", name: "anchore/grype" },
+  SEMGREP_VERSION: { type: "pypi", name: "semgrep" },
+  SYFT_VERSION: { type: "docker", name: "anchore/syft" },
+  TRIVY_VERSION: { type: "docker", name: "aquasec/trivy" },
+};
+
+const toolVersionCache = new Map();
+
+// ---------- HTTP helpers ----------
+
+const fetchJson = async (url) => {
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+
+  if (!res.ok) {
+    throw new Error(`Request failed (${res.status}) for ${url}`);
+  }
+
+  return res.json();
+};
+
+const fetchDockerTags = async (repo) => {
+  const tags = [];
+  const tagUrl = new URL(`${config.dockerHubApiUrl}/${repo}/tags`);
+  tagUrl.searchParams.set("page_size", String(config.dockerTagPageSize));
+  let url = tagUrl.toString();
+
+  for (let page = 0; url && page < config.maxDockerTagPages; page++) {
+    const data = await fetchJson(url);
+
+    tags.push(...(data.results ?? []).map((t) => t.name).filter(Boolean));
+    url = data.next ?? "";
+  }
+
+  return tags;
+};
+
+const fetchPypiVersions = async (pkg) => {
+  const data = await fetchJson(`${config.pypiApiUrl}/${pkg}/json`);
+
+  return Object.entries(data.releases ?? {})
+    .filter(([, files]) => files.some((file) => !file.yanked))
+    .map(([version]) => version);
+};
+
+const dockerTagExists = async (repo, tag) => {
+  const res = await fetch(`${config.dockerHubApiUrl}/${repo}/tags/${tag}`);
+
+  if (res.status === 404) {
+    return false;
+  }
+
+  if (!res.ok) {
+    throw new Error(
+      `Docker tag check failed (${res.status}) for ${repo}:${tag}`,
+    );
+  }
+
+  return true;
+};
+
+const fetchToolVersions = (variable) => {
+  if (toolVersionCache.has(variable)) {
+    return toolVersionCache.get(variable);
+  }
+
+  const source = toolSources[variable];
+
+  if (!source) {
+    throw new Error(`Unsupported tool variable '${variable}'.`);
+  }
+
+  const versions =
+    source.type === "docker"
+      ? fetchDockerTags(source.name)
+      : source.type === "pypi"
+        ? fetchPypiVersions(source.name)
+        : null;
+
+  if (!versions) {
+    throw new Error(`Unsupported source type '${source.type}'.`);
+  }
+
+  toolVersionCache.set(variable, versions);
+
+  return versions;
+};
+
+// ---------- Version helpers ----------
+
+const parseVersion = (version) => {
+  const m = String(version).match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+
+  return m && { major: +m[1], minor: +m[2], patch: +m[3] };
+};
+
+const compareVersions = (a, b) =>
+  a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+
+const formatVersion = ({ major, minor, patch }) => `${major}.${minor}.${patch}`;
+
+const versionPrefix = (version) => (String(version).startsWith("v") ? "v" : "");
+
+const classifyUpdate = (currentVersion, latestVersion) => {
+  const current = parseVersion(currentVersion);
+  const latest = parseVersion(latestVersion);
+
+  if (!current || !latest) {
+    return "invalid-version";
+  } else if (latest.major !== current.major) {
+    return "different-major";
+  } else if (latest.minor > current.minor) {
+    return "minor";
+  } else if (latest.minor === current.minor && latest.patch > current.patch) {
+    return "patch";
+  } else if (latest.minor === current.minor && latest.patch === current.patch) {
+    return "no-op";
+  } else {
+    return "ahead-of-release-index";
+  }
+};
+
+const selectSemver = (versions, currentVersion, scope, desiredPrefix) => {
+  const current = parseVersion(currentVersion);
+
+  if (!current) {
+    return "";
+  }
+
+  const best = [...versions, currentVersion]
+    .map((raw) => parseVersion(raw))
+    .filter(
+      (candidate) =>
+        candidate &&
+        (scope === "new-major" ||
+          (candidate.major === current.major &&
+            (scope === "minor" || candidate.minor === current.minor))),
+    )
+    .sort(compareVersions)
+    .at(-1);
+
+  return best ? `${desiredPrefix}${formatVersion(best)}` : "";
+};
+
+const readNodeReleaseIndex = async () =>
+  config.nodeReleaseIndexPath
+    ? JSON.parse(await readFile(config.nodeReleaseIndexPath, "utf8"))
+    : fetchJson(config.nodeReleaseIndexUrl);
+
+// ---------- Env file discovery ----------
+
+const parseEnvFile = async (image, path) => {
+  const variables = {};
+
+  for (const line of (await readFile(path, "utf8")).split("\n")) {
+    const match = line.match(/^([A-Z_]+)=(.*)$/);
+
+    if (match) {
+      variables[match[1]] = match[2];
+    }
+  }
+
+  return {
+    image,
+    path,
+    major: Number(basename(path)),
+    nodeVersion: variables.NODE_VERSION ?? "",
+    variables,
+  };
+};
+
+const collectEnvFiles = async () => {
+  const files = [];
+
+  for (const [image, meta] of Object.entries(images)) {
+    let entries = [];
+
+    try {
+      entries = await readdir(meta.dir, { withFileTypes: true });
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        continue;
+      }
+
+      throw error;
+    }
+
+    for (const entry of entries) {
+      if (entry.isFile() && /^\d+$/.test(entry.name)) {
+        files.push(await parseEnvFile(image, join(meta.dir, entry.name)));
+      }
+    }
+  }
+
+  return files.sort(
+    (a, b) => a.major - b.major || a.image.localeCompare(b.image),
+  );
+};
+
+const latestEnvFile = (envFiles, image) =>
+  envFiles
+    .filter((f) => f.image === image)
+    .sort((a, b) => a.major - b.major)
+    .at(-1) ?? null;
+
+const latestEvenNodeReleases = (releaseIndex) => {
+  const latestByMajor = new Map();
+
+  for (const release of releaseIndex) {
+    const parsed = parseVersion(release.version);
+
+    if (!parsed || parsed.major % 2 !== 0) {
+      continue;
+    }
+
+    const current = latestByMajor.get(parsed.major);
+
+    if (!current || compareVersions(parsed, current) > 0) {
+      latestByMajor.set(parsed.major, {
+        ...parsed,
+        version: formatVersion(parsed),
+      });
+    }
+  }
+
+  return [...latestByMajor.values()].sort(compareVersions);
+};
+
+// ---------- Update preparation ----------
+
+const createUpdate = (
+  image,
+  release,
+  existing,
+  template,
+  maxSupportedMajor,
+) => {
+  if (existing) {
+    const classification = classifyUpdate(
+      existing.nodeVersion,
+      release.version,
+    );
+
+    if (classification !== "minor" && classification !== "patch") {
+      return null;
+    }
+
+    return {
+      image,
+      major: release.major,
+      path: existing.path,
+      currentNodeVersion: existing.nodeVersion,
+      latestNodeVersion: release.version,
+      classification,
+      variables: existing.variables,
+    };
+  }
+
+  if (
+    !template ||
+    maxSupportedMajor === null ||
+    release.major < maxSupportedMajor
+  ) {
+    return null;
+  }
+
+  return {
+    image,
+    major: release.major,
+    path: join(images[image].dir, String(release.major)),
+    currentNodeVersion: "",
+    latestNodeVersion: release.version,
+    classification: "new-major",
+    variables: template.variables,
+  };
+};
+
+const resolveToolUpdates = async (image, variables, classification) => {
+  const resolved = await Promise.all(
+    images[image].tools.map(async (tool) => {
+      const current = variables[tool];
+
+      if (!current) {
+        throw new Error(`Missing ${tool} in ${image} variables.`);
+      }
+
+      let versions;
+
+      try {
+        versions = await fetchToolVersions(tool);
+      } catch (error) {
+        throw new Error(`${tool}: ${error.message}`);
+      }
+
+      const selected = selectSemver(
+        versions,
+        current,
+        classification,
+        versionPrefix(current),
+      );
+
+      if (!selected) {
+        throw new Error(`no eligible version for ${tool}`);
+      }
+
+      return { variable: tool, current, selected };
+    }),
+  );
+  const selectedByTool = new Map(
+    resolved.map(({ variable, selected }) => [variable, selected]),
+  );
+
+  return {
+    variables: Object.fromEntries(
+      Object.entries(variables).map(([key, value]) => [
+        key,
+        selectedByTool.get(key) ?? value,
+      ]),
+    ),
+    toolChanges: resolved.filter(
+      ({ current, selected }) => selected !== current,
+    ),
+  };
+};
+
+const prepareUpdate = async (update) => {
+  const { image, major, latestNodeVersion: nodeVersion } = update;
+  const variables = {
+    ...update.variables,
+    NODE_VERSION: nodeVersion,
+    IMAGE_TAGS: `(${nodeVersion} ${major})`,
+  };
+
+  if (
+    image === "secrets" &&
+    !(await dockerTagExists("cimg/node", nodeVersion))
+  ) {
+    return {
+      skip: {
+        image,
+        major,
+        nodeVersion,
+        reason: `missing cimg/node:${nodeVersion}`,
+      },
+    };
+  }
+
+  const resolved = await resolveToolUpdates(
+    image,
+    variables,
+    update.classification,
+  );
+
+  return {
+    write: {
+      path: update.path,
+      image,
+      variables: resolved.variables,
+    },
+    change: {
+      path: update.path,
+      major,
+      currentNodeVersion: update.currentNodeVersion,
+      latestNodeVersion: nodeVersion,
+      classification: update.classification,
+      toolChanges: resolved.toolChanges,
+    },
+  };
+};
+
+const buildUpdates = async (releases, envFiles) => {
+  const filesByImageMajor = new Map(
+    envFiles.map((file) => [`${file.image}:${file.major}`, file]),
+  );
+  const maxSupportedMajor = envFiles.length
+    ? Math.max(...envFiles.map((file) => file.major))
+    : null;
+  const templates = Object.fromEntries(
+    Object.keys(images).map((image) => [image, latestEnvFile(envFiles, image)]),
+  );
+  const result = {
+    writes: [],
+    changes: Object.fromEntries(
+      Object.keys(images).map((image) => [image, []]),
+    ),
+    skipped: [],
+  };
+
+  for (const release of releases) {
+    const secrets = createUpdate(
+      "secrets",
+      release,
+      filesByImageMajor.get(`secrets:${release.major}`),
+      templates.secrets,
+      maxSupportedMajor,
+    );
+    const secretsResult = secrets && (await prepareUpdate(secrets));
+
+    if (secretsResult?.skip) {
+      result.skipped.push(secretsResult.skip);
+    } else if (secretsResult) {
+      result.writes.push(secretsResult.write);
+      result.changes.secrets.push(secretsResult.change);
+    }
+
+    const security = createUpdate(
+      "security",
+      release,
+      filesByImageMajor.get(`security:${release.major}`),
+      templates.security,
+      maxSupportedMajor,
+    );
+
+    if (!security) {
+      continue;
+    }
+
+    if (secretsResult?.skip) {
+      result.skipped.push({
+        image: "security",
+        major: release.major,
+        nodeVersion: release.version,
+        reason: `blocked by skipped node-secrets:${release.version}`,
+      });
+      continue;
+    }
+
+    const securityResult = await prepareUpdate(security);
+
+    result.writes.push(securityResult.write);
+    result.changes.security.push(securityResult.change);
+  }
+
+  return result;
+};
+
+// ---------- Apply & output ----------
+
+const renderEnvFile = ({ image, variables }) =>
+  `${images[image].variables.map((variable) => `${variable}=${variables[variable]}`).join("\n")}\n`;
+
+const applyWrites = async (writes) => {
+  for (const write of writes) {
+    await writeFile(write.path, renderEnvFile(write), "utf8");
+  }
+};
+
+const planUpdates = async () => {
+  const [releaseIndex, envFiles] = await Promise.all([
+    readNodeReleaseIndex(),
+    collectEnvFiles(),
+  ]);
+
+  return buildUpdates(latestEvenNodeReleases(releaseIndex), envFiles);
+};
+
+const discover = async ({ mode }) => {
+  const result = await planUpdates();
+
+  if (mode === "apply") {
+    await applyWrites(result.writes);
+  }
+
+  return {
+    dryRun: mode === "dry-run",
+    generatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    changes: result.changes,
+    skipped: result.skipped,
+  };
+};
+
+// ---------- CLI entry ----------
+
+const parseArgs = (args) => {
+  if (args.length !== 1) {
+    throw new Error("One argument is required, '--apply' or '--dry-run'");
+  }
+
+  const [arg] = args;
+
+  if (arg === "--dry-run" || arg === "--apply") {
+    return arg.replace(/^--/, ""); // Get selected mode
+  }
+
+  throw new Error(`Unknown argument '${arg}'`);
+};
+
+const validateConfig = (mode) => {
+  if (mode !== "apply") {
+    return;
+  }
+
+  if (!config.discoveryReportPath) {
+    throw new Error("Env DISCOVERY_REPORT_PATH is required");
+  }
+};
+
+try {
+  const mode = parseArgs(process.argv.slice(2));
+
+  validateConfig(mode);
+
+  const result = await discover({ mode });
+  const output = `${JSON.stringify(result, null, 2)}\n`;
+
+  if (mode === "apply") {
+    await writeFile(config.discoveryReportPath, output, "utf8");
+  }
+
+  process.stdout.write(output);
+} catch (error) {
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/updates/pr-helpers.sh
+++ b/scripts/updates/pr-helpers.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck disable=SC2034 # used by scripts that source this file
+BASE_BRANCH="master"
+# shellcheck disable=SC2034 # used by scripts that source this file
+SECRETS_UPDATES_BRANCH="automation/node-secrets-updates"
+# shellcheck disable=SC2034 # used by scripts that source this file
+SECURITY_UPDATES_BRANCH="automation/node-security-updates"
+
+fail() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+ensure_git_identity() {
+  local name email
+
+  name="$(git config user.name || true)"
+  email="$(git config user.email || true)"
+
+  if [[ -z "$name" || -z "$email" ]]; then
+    fail "Git user.name and user.email must be configured."
+  fi
+}
+
+ensure_github_auth() {
+  gh auth status >/dev/null
+}
+
+require_discovery_report_path() {
+  local value="${DISCOVERY_REPORT_PATH:-}"
+
+  [[ -n "${value//[[:space:]]/}" ]] ||
+    fail "DISCOVERY_REPORT_PATH is required"
+}
+
+validate_report() {
+  local image="$1"
+
+  require_discovery_report_path
+  [[ -f "$DISCOVERY_REPORT_PATH" ]] || fail "Discovery report not found: $DISCOVERY_REPORT_PATH"
+
+  jq -e --arg image "$image" '
+    (.changes[$image] | type == "array") and (.skipped | type == "array")
+  ' "$DISCOVERY_REPORT_PATH" >/dev/null || fail "Discovery report is missing changes.$image or skipped entries."
+}
+
+changed_paths() {
+  local dir="$1"
+
+  git status --porcelain -- "$dir" |
+    while IFS= read -r line; do
+      local path="${line:3}"
+      printf '%s\n' "${path##* -> }"
+    done |
+    sed '/^$/d'
+}
+
+expected_paths() {
+  local image="$1"
+
+  jq -r --arg image "$image" '.changes[$image][].path' "$DISCOVERY_REPORT_PATH"
+}
+
+update_message() {
+  local image_key="$1"
+  local image_name="$2"
+  local restrict_to_paths=false
+  local included_paths_json
+
+  shift 2
+
+  if (($# > 0)); then
+    restrict_to_paths=true
+    included_paths_json="$(paths_json "$@")"
+  else
+    included_paths_json='[]'
+  fi
+
+  jq -er \
+    --arg image "$image_key" \
+    --arg imageName "$image_name" \
+    --argjson restrictToPaths "$restrict_to_paths" \
+    --argjson includedPaths "$included_paths_json" '
+      .changes[$image]
+      | if type == "array" then . else error("Discovery report is missing changes." + $image) end
+      | if $restrictToPaths then
+          map(select(.path as $path | $includedPaths | index($path)))
+        else
+          .
+        end
+      | map(
+          .latestNodeVersion
+          | if type == "string" and length > 0 then . else error("Missing latestNodeVersion for " + $image) end
+        )
+      | reduce .[] as $version ([]; if index($version) then . else . + [$version] end)
+      | if length == 0 then error("No " + $imageName + " versions selected for update message") else . end
+      | "feat: `\($imageName)` \(join(", "))"
+    ' "$DISCOVERY_REPORT_PATH"
+}
+
+assert_paths_match_report() {
+  local image="$1"
+  local label="$2"
+  local dir="$3"
+  local tmp_dir expected actual
+
+  tmp_dir="$(mktemp -d)"
+  expected="$tmp_dir/expected"
+  actual="$tmp_dir/actual"
+
+  expected_paths "$image" | sort >"$expected"
+  changed_paths "$dir" | sort >"$actual"
+
+  if ! diff -u "$expected" "$actual" >/dev/null; then
+    printf 'Discovery report does not match applied %s changes.\n' "$label" >&2
+    printf 'Expected paths:\n' >&2
+    sed 's/^/- /' "$expected" >&2
+    printf 'Actual paths:\n' >&2
+    sed 's/^/- /' "$actual" >&2
+    rm -rf "$tmp_dir"
+    exit 1
+  fi
+
+  rm -rf "$tmp_dir"
+}
+
+assert_only_paths() {
+  local dir="$1"
+  local label="$2"
+  shift 2
+  local invalid=()
+
+  for path in "$@"; do
+    if [[ "$path" != "$dir"* ]]; then
+      invalid+=("$path")
+    fi
+  done
+
+  if ((${#invalid[@]} > 0)); then
+    fail "$label PR contains invalid changes: ${invalid[*]}"
+  fi
+}
+
+paths_json() {
+  if (($# == 0)); then
+    printf '[]\n'
+    return
+  fi
+
+  printf '%s\n' "$@" | jq -R -s 'split("\n") | map(select(length > 0))'
+}
+
+remote_branch_oid() {
+  local branch="$1"
+  local output
+
+  output="$(git ls-remote --heads origin "refs/heads/$branch")" ||
+    fail "Unable to read remote branch origin/$branch"
+
+  if [[ -n "$output" ]]; then
+    printf '%s\n' "${output%%$'\t'*}"
+  fi
+}
+
+prepare_publish_worktree() {
+  local branch="$1"
+  local base_branch="$2"
+  local worktree="$3"
+
+  git fetch origin "$base_branch"
+  PUSH_LEASE_BRANCH="$branch"
+  PUSH_LEASE_EXPECTED_SHA="$(remote_branch_oid "$branch")"
+  git worktree add --force -B "$branch" "$worktree" "origin/$base_branch"
+}
+
+remove_publish_worktree() {
+  local worktree="$1"
+
+  [[ -n "$worktree" && -d "$worktree" ]] || return 0
+  git worktree remove --force "$worktree"
+}
+
+PUSH_LEASE_BRANCH=""
+PUSH_LEASE_EXPECTED_SHA=""
+
+staged_paths() {
+  git diff --cached --name-only
+}
+
+push_branch() {
+  local branch="$1"
+  local worktree="$2"
+
+  [[ "$PUSH_LEASE_BRANCH" == "$branch" ]] ||
+    fail "No push lease was established for branch: $branch"
+
+  git -C "$worktree" push \
+    "--force-with-lease=refs/heads/$branch:$PUSH_LEASE_EXPECTED_SHA" \
+    origin "$branch:$branch"
+}
+
+find_pr_json() {
+  local branch="$1"
+  local base_branch="$2"
+
+  gh pr list \
+    --head "$branch" \
+    --base "$base_branch" \
+    --state open \
+    --json number,url,isDraft,body,headRefOid \
+    --jq '.[0] // empty'
+}
+
+pr_number_from_json() {
+  jq -r '.number // empty' <<<"$1"
+}
+
+refresh_pr_json() {
+  local number="$1"
+
+  gh pr view "$number" --json number,url,isDraft,body,headRefOid
+}
+
+create_or_update_pr() {
+  local branch="$1"
+  local base_branch="$2"
+  local title="$3"
+  local body_file="$4"
+  local draft="${5:-false}"
+  local existing number pr action
+  local -a create_args=()
+
+  existing="$(find_pr_json "$branch" "$base_branch")"
+
+  if [[ -n "$existing" ]]; then
+    number="$(pr_number_from_json "$existing")"
+    gh pr edit "$number" --title "$title" --body-file "$body_file" >/dev/null
+    action="updated"
+  else
+    [[ "$draft" == "true" ]] && create_args+=(--draft)
+    gh pr create \
+      --title "$title" \
+      --body-file "$body_file" \
+      --base "$base_branch" \
+      --head "$branch" \
+      "${create_args[@]}" >/dev/null
+    number="$(pr_number_from_json "$(find_pr_json "$branch" "$base_branch")")"
+    action="created"
+  fi
+
+  pr="$(refresh_pr_json "$number")"
+  if [[ "$draft" == "true" && "$(jq -r '.isDraft' <<<"$pr")" != "true" ]]; then
+    gh pr ready "$number" --undo >/dev/null
+    pr="$(refresh_pr_json "$number")"
+  fi
+
+  jq -c --arg action "$action" '. + {action: $action}' <<<"$pr"
+}

--- a/scripts/updates/publish-node-updates-pr.sh
+++ b/scripts/updates/publish-node-updates-pr.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=scripts/updates/pr-helpers.sh
+source "$SCRIPT_DIR/pr-helpers.sh"
+
+if (($# != 1)); then
+  fail "Usage: $0 <secrets|security>"
+fi
+
+MODE="$1"
+case "$MODE" in
+secrets)
+  BRANCH="$SECRETS_UPDATES_BRANCH"
+  IMAGE_DIR="node/secrets/"
+  IMAGE_NAME="node-secrets"
+  DRAFT=false
+  ;;
+security)
+  BRANCH="$SECURITY_UPDATES_BRANCH"
+  IMAGE_DIR="node/security/"
+  IMAGE_NAME="node-security"
+  DRAFT=true
+  ;;
+*)
+  fail "Unknown publisher mode: $MODE"
+  ;;
+esac
+
+format_secrets_body() {
+  local body_file="$1"
+
+  jq -r -f <(
+    cat <<'EOF'
+def toolChanges(change):
+  if (change.toolChanges | length) == 0 then
+    "Infisical unchanged"
+  else
+    change.toolChanges
+    | map("Infisical \(.current) -> \(.selected)")
+    | join(", ")
+  end;
+
+[
+  "## Summary", "",
+  "Updates `node-secrets` env files for eligible even-major Node.js releases.", "",
+  "## Changes", "",
+  (if (.changes.secrets | length) > 0 then .changes.secrets[] | "- `\(.path)`: Node \(.currentNodeVersion // "new") -> \(.latestNodeVersion) (\(.classification)); \(toolChanges(.))" else "- No `node-secrets` changes." end),
+  "", "## Skipped", "",
+  ([.skipped[] | select(.image == "secrets") | "- Node \(.major) (\(.nodeVersion)): \(.reason)"] | if length > 0 then .[] else "- None" end),
+  "", "## Merge Notes", "",
+  "Squash-merge this PR so the existing image-change detector sees all env file changes in one final commit."
+] | join("\n")
+EOF
+  ) "$DISCOVERY_REPORT_PATH" >"$body_file"
+}
+
+format_security_body() {
+  local body_file="$1"
+  local secrets_pr="$2"
+  local dependency url
+
+  url="$(jq -r '.url // empty' <<<"$secrets_pr")"
+  if [[ -n "$url" ]]; then
+    dependency="Depends on \`node-secrets\` PR $url."
+  else
+    dependency="Depends on the \`node-secrets\` update PR from branch \`$SECRETS_UPDATES_BRANCH\`."
+  fi
+
+  jq -r --arg dependency "$dependency" -f <(
+    cat <<'EOF'
+def toolChanges(change):
+  if (change.toolChanges | length) == 0 then
+    "security tools unchanged"
+  else
+    change.toolChanges
+    | map("\(.variable) \(.current) -> \(.selected)")
+    | join(", ")
+  end;
+
+[
+  "## Summary", "",
+  "Updates `node-security` env files for eligible even-major Node.js releases.", "",
+  "## Dependency", "",
+  $dependency,
+  "Do not merge this PR until the matching `studiondev/node-secrets:<NODE_VERSION>` image tags are published.",
+  "This PR is created as draft/blocked by default; the dependency gate updates readiness after checking the required image tags.",
+  "", "## Changes", "",
+  (if (.changes.security | length) > 0 then .changes.security[] | "- `\(.path)`: Node \(.currentNodeVersion // "new") -> \(.latestNodeVersion) (\(.classification)); \(toolChanges(.))" else "- No node-security changes." end),
+  "", "## Skipped", "",
+  ([.skipped[] | select(.image == "security") | "- Node \(.major) (\(.nodeVersion)): \(.reason)"] | if length > 0 then .[] else "- None" end),
+  "", "## Merge Notes", "",
+  "Squash-merge this PR so the existing image-change detector sees all env file changes in one final commit."
+] | join("\n")
+EOF
+  ) "$DISCOVERY_REPORT_PATH" >"$body_file"
+}
+
+validate_report "$MODE"
+
+if [[ "$(jq ".changes.$MODE | length" "$DISCOVERY_REPORT_PATH")" == "0" ]]; then
+  printf 'No %s changes to publish.\n' "$IMAGE_NAME"
+  exit 0
+fi
+
+paths=()
+while IFS= read -r path; do
+  paths+=("$path")
+done < <(expected_paths "$MODE")
+assert_paths_match_report "$MODE" "$IMAGE_NAME" "$IMAGE_DIR"
+assert_only_paths "$IMAGE_DIR" "$IMAGE_NAME" "${paths[@]}"
+
+body_file="$(mktemp)"
+worktree="$(mktemp -d)"
+rmdir "$worktree"
+cleanup() {
+  local status=$?
+  trap - EXIT
+  remove_publish_worktree "$worktree" || rm -rf "$worktree"
+  rm -f "$body_file"
+  exit "$status"
+}
+trap cleanup EXIT
+
+ensure_git_identity
+ensure_github_auth
+if [[ "$MODE" == security ]]; then
+  format_security_body "$body_file" "$(find_pr_json "$SECRETS_UPDATES_BRANCH" "$BASE_BRANCH")"
+else
+  format_secrets_body "$body_file"
+fi
+
+prepare_publish_worktree "$BRANCH" "$BASE_BRANCH" "$worktree"
+for path in "${paths[@]}"; do
+  mkdir -p "$worktree/$(dirname "$path")"
+  cp "$path" "$worktree/$path"
+done
+
+git -C "$worktree" add "${paths[@]}"
+staged=()
+while IFS= read -r path; do
+  staged+=("$path")
+done < <(git -C "$worktree" diff --cached --name-only)
+if ((${#staged[@]} > 0)); then
+  assert_only_paths "$IMAGE_DIR" "$IMAGE_NAME" "${staged[@]}"
+  title="$(update_message "$MODE" "$IMAGE_NAME" "${staged[@]}")"
+  git -C "$worktree" commit -m "$title"
+  push_branch "$BRANCH" "$worktree"
+  create_or_update_pr "$BRANCH" "$BASE_BRANCH" "$title" "$body_file" "$DRAFT" >/dev/null
+  printf 'Published %s update PR.\n' "$IMAGE_NAME"
+  exit 0
+fi
+
+title="$(update_message "$MODE" "$IMAGE_NAME")"
+existing="$(find_pr_json "$BRANCH" "$BASE_BRANCH")"
+if [[ -n "$existing" ]]; then
+  create_or_update_pr "$BRANCH" "$BASE_BRANCH" "$title" "$body_file" "$DRAFT" >/dev/null
+  printf 'Refreshed existing %s update PR; no new commit was needed.\n' "$IMAGE_NAME"
+else
+  printf 'No new %s commit was needed and no existing PR was found.\n' "$IMAGE_NAME"
+fi

--- a/scripts/updates/update-security-pr-gate.sh
+++ b/scripts/updates/update-security-pr-gate.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=scripts/updates/pr-helpers.sh
+source "$SCRIPT_DIR/pr-helpers.sh"
+
+BRANCH="$SECURITY_UPDATES_BRANCH"
+DOCKER_HUB_API_URL="${DOCKER_HUB_API_URL:-https://hub.docker.com/v2/repositories}"
+GATE_START='<!-- node-security-dependency-gate:start -->'
+GATE_END='<!-- node-security-dependency-gate:end -->'
+
+if (($# > 0)); then
+  fail "Unexpected arguments: $*"
+fi
+
+security_files_from_pr() {
+  gh pr view "$1" --json files --jq '.files[].path | select(test("^node/security/[0-9]+$"))'
+}
+
+node_version_from_pr_file() {
+  local repository="$1" head_ref_oid="$2" path="$3" content version
+
+  content="$(gh api -H 'Accept: application/vnd.github.raw+json' "repos/$repository/contents/$path?ref=$head_ref_oid")" ||
+    fail "Unable to read $path at security PR head $head_ref_oid"
+  version="$(awk -F= '$1 == "NODE_VERSION" { print $2; exit }' <<<"$content")"
+  [[ -n "$version" ]] || fail "Missing NODE_VERSION in $path at security PR head $head_ref_oid"
+  printf '%s\n' "$version"
+}
+
+required_tags_json() {
+  local pr_json="$1" number repository head_ref_oid path node_version
+
+  number="$(pr_number_from_json "$pr_json")"
+  repository="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')" || fail "Unable to determine the GitHub repository"
+  [[ -n "$repository" ]] || fail "GitHub repository name is empty"
+  head_ref_oid="$(jq -r '.headRefOid' <<<"$pr_json")"
+
+  while IFS= read -r path; do
+    [[ -n "$path" ]] || continue
+    node_version="$(node_version_from_pr_file "$repository" "$head_ref_oid" "$path")"
+    jq -n --arg path "$path" --argjson major "${path##*/}" --arg nodeVersion "$node_version" \
+      '{path: $path, major: $major, nodeVersion: $nodeVersion}'
+  done < <(security_files_from_pr "$number") | jq -s '.'
+}
+
+docker_tag_statuses_json() {
+  jq -c '.[]' | while IFS= read -r tag; do
+    local path major node_version status
+    path="$(jq -r '.path' <<<"$tag")"
+    major="$(jq -r '.major' <<<"$tag")"
+    node_version="$(jq -r '.nodeVersion' <<<"$tag")"
+    status="$(curl -fsS -o /dev/null -w '%{http_code}' "$DOCKER_HUB_API_URL/studiondev/node-secrets/tags/$node_version" || true)"
+
+    case "$status" in
+    200) jq -n --arg path "$path" --argjson major "$major" --arg nodeVersion "$node_version" '{path: $path, major: $major, nodeVersion: $nodeVersion, available: true}' ;;
+    404) jq -n --arg path "$path" --argjson major "$major" --arg nodeVersion "$node_version" '{path: $path, major: $major, nodeVersion: $nodeVersion, available: false}' ;;
+    *) fail "Docker tag check failed (${status:-curl error}) for studiondev/node-secrets:$node_version" ;;
+    esac
+  done | jq -s '.'
+}
+
+dependency_section() {
+  jq -r --arg start "$GATE_START" --arg end "$GATE_END" '
+    ([.[] | select(.available == false)] | length) as $missing |
+    [
+      $start, "## Dependency Gate", "",
+      "Status: **\(if $missing == 0 then "ready" else "blocked" end)**", "",
+      "Required node-secrets image tags:", "",
+      (.[] | "- `studiondev/node-secrets:\(.nodeVersion)`: \(if .available then "available" else "missing" end)"), "",
+      (if $missing == 0 then "All required node-secrets images are published. This PR can be marked ready." else "Keep this PR draft/blocked until all required node-secrets images are published." end),
+      $end
+    ] | join("\n")'
+}
+
+upsert_dependency_section() {
+  local body="$1" section="$2"
+
+  # shellcheck disable=SC2016
+  BODY="$body" SECTION="$section" node -e '
+    const body = process.env.BODY.replace(/\n+$/, "");
+    const section = process.env.SECTION.replace(/\n+$/, "");
+    const pattern = /<!-- node-security-dependency-gate:start -->[\s\S]*<!-- node-security-dependency-gate:end -->/;
+    process.stdout.write(`${pattern.test(body) ? body.replace(pattern, section) : `${body}\n\n${section}`}\n`);
+  '
+}
+
+ensure_github_auth
+pr_json="$(find_pr_json "$BRANCH" "$BASE_BRANCH")"
+if [[ -z "$pr_json" ]]; then
+  printf 'No open node-security PR found.\n'
+  exit 0
+fi
+
+pr_json="$(refresh_pr_json "$(pr_number_from_json "$pr_json")")"
+required_tags="$(required_tags_json "$pr_json")"
+if [[ "$(jq 'length' <<<"$required_tags")" == "0" ]]; then
+  printf 'Security PR has no node/security env file changes.\n'
+  exit 0
+fi
+
+statuses="$(docker_tag_statuses_json <<<"$required_tags")"
+body="$(jq -r '.body // ""' <<<"$pr_json")"
+updated_body="$(upsert_dependency_section "$body" "$(dependency_section <<<"$statuses")")"
+number="$(pr_number_from_json "$pr_json")"
+missing_count="$(jq '[.[] | select(.available == false)] | length' <<<"$statuses")"
+is_draft="$(jq -r '.isDraft' <<<"$pr_json")"
+gh pr edit "$number" --body "$updated_body" >/dev/null
+
+if [[ "$missing_count" == 0 ]]; then
+  [[ "$is_draft" != true ]] || gh pr ready "$number" >/dev/null
+  printf 'Security dependency gate: ready.\n'
+else
+  [[ "$is_draft" == true ]] || gh pr ready "$number" --undo >/dev/null
+  printf 'Security dependency gate: blocked.\n'
+fi

--- a/scripts/updates/validate.sh
+++ b/scripts/updates/validate.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DISCOVERY_SCRIPT="$SCRIPT_DIR/discover-node-updates.js"
+PUBLISHER_SCRIPT="$SCRIPT_DIR/publish-node-updates-pr.sh"
+UPDATE_SCRIPTS=(
+  "$SCRIPT_DIR/pr-helpers.sh"
+  "$PUBLISHER_SCRIPT"
+  "$SCRIPT_DIR/update-security-pr-gate.sh"
+  "$SCRIPT_DIR/validate.sh"
+)
+
+run_static_checks() {
+  local script
+
+  node --check "$DISCOVERY_SCRIPT"
+  for script in "${UPDATE_SCRIPTS[@]}"; do
+    bash -n "$script"
+  done
+
+  if command -v shellcheck >/dev/null 2>&1; then
+    shellcheck -x "${UPDATE_SCRIPTS[@]}"
+  fi
+}
+
+write_env_files() {
+  local root="$1" major
+
+  mkdir -p "$root/node/secrets" "$root/node/security"
+  for major in 22 24; do
+    cat >"$root/node/secrets/$major" <<EOF
+NODE_VERSION=$major.1.0
+INFISICAL_VERSION=0.20.0
+IMAGE_TAGS=($major.1.0 $major)
+EOF
+    cat >"$root/node/security/$major" <<EOF
+NODE_VERSION=$major.1.0
+GITLEAKS_VERSION=v8.1.0
+GRYPE_VERSION=v0.90.0
+SEMGREP_VERSION=1.50.0
+SYFT_VERSION=v0.90.0
+TRIVY_VERSION=0.50.0
+IMAGE_TAGS=($major.1.0 $major)
+EOF
+  done
+}
+
+write_release_index() {
+  cat >"$1" <<'JSON'
+[
+  {"version":"v22.1.1"},
+  {"version":"v24.2.0"},
+  {"version":"v25.0.0"},
+  {"version":"v26.0.0"}
+]
+JSON
+}
+
+write_mock_server() {
+  cat >"$1" <<'NODE'
+import { createServer } from "node:http";
+import { writeFileSync } from "node:fs";
+
+const portFile = process.argv[2];
+const dockerTags = {
+  "/repositories/infisical/cli/tags": ["0.20.1", "0.21.0", "1.0.0"],
+  "/repositories/zricethezav/gitleaks/tags": ["v8.1.1", "v8.2.0", "v9.0.0"],
+  "/repositories/anchore/grype/tags": ["v0.90.1", "v0.91.0", "v1.0.0"],
+  "/repositories/anchore/syft/tags": ["v0.90.1", "v0.91.0", "v1.0.0"],
+  "/repositories/aquasec/trivy/tags": ["0.50.1", "0.51.0", "1.0.0"],
+};
+const json = (res, status, body) => {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+};
+const server = createServer((req, res) => {
+  const url = new URL(req.url, "http://localhost");
+
+  if (["22.1.1", "24.2.0", "26.0.0"].includes(url.pathname.split("/").at(-1)) &&
+      url.pathname.startsWith("/repositories/cimg/node/tags/")) {
+    json(res, 200, { name: url.pathname.split("/").at(-1) });
+  } else if (dockerTags[url.pathname]) {
+    json(res, 200, { results: dockerTags[url.pathname].map((name) => ({ name })), next: null });
+  } else if (url.pathname === "/pypi/semgrep/json") {
+    json(res, 200, { releases: {
+      "1.50.1": [{ yanked: false }], "1.51.0": [{ yanked: false }], "2.0.0": [{ yanked: false }],
+    }});
+  } else {
+    json(res, 404, { message: "not found", path: url.pathname });
+  }
+});
+server.listen(0, "127.0.0.1", () => writeFileSync(portFile, String(server.address().port)));
+NODE
+}
+
+wait_for_file() {
+  local path="$1" _
+
+  for _ in {1..50}; do
+    [[ -s "$path" ]] && return
+    sleep 0.1
+  done
+  printf 'Timed out waiting for %s\n' "$path" >&2
+  return 1
+}
+
+assert_json() {
+  jq -e "$2" <<<"$1" >/dev/null
+}
+
+assert_env_value() {
+  local file="$1" variable="$2" expected="$3" actual
+
+  actual="$(awk -F= -v variable="$variable" '$1 == variable { print $2; exit }' "$file")"
+  [[ "$actual" == "$expected" ]] || {
+    printf 'Expected %s=%s in %s, got %s\n' "$variable" "$expected" "$file" "$actual" >&2
+    exit 1
+  }
+}
+
+expect_failure() {
+  local description="$1" expected="$2" output
+  shift 2
+
+  if output="$("$@" 2>&1)"; then
+    printf '%s unexpectedly succeeded\n' "$description" >&2
+    return 1
+  fi
+  [[ "$output" == *"$expected"* ]] || {
+    printf '%s did not report %q:\n%s\n' "$description" "$expected" "$output" >&2
+    return 1
+  }
+}
+
+# Fixture state is inherited by the synchronous discovery test callback.
+# shellcheck disable=SC2030,SC2031
+with_discovery_fixture() (
+  local test="$1" tmp server_pid
+
+  tmp="$(mktemp -d)"
+  root="$tmp/repo"
+  release_index="$tmp/release-index.json"
+  report="$tmp/report.json"
+  server_script="$tmp/mock-server.mjs"
+  port_file="$tmp/port"
+  trap '
+    kill "${server_pid:-}" >/dev/null 2>&1 || true
+    wait "${server_pid:-}" 2>/dev/null || true
+    rm -rf "$tmp"
+  ' EXIT
+
+  mkdir -p "$root"
+  write_env_files "$root"
+  write_release_index "$release_index"
+  write_mock_server "$server_script"
+  node "$server_script" "$port_file" >/dev/null 2>&1 &
+  server_pid=$!
+  wait_for_file "$port_file"
+  base_url="http://127.0.0.1:$(<"$port_file")"
+  "$test"
+)
+
+# shellcheck disable=SC2031
+run_discovery() (
+  local mode="$1" setting
+  shift
+  cd "$root"
+  export NODE_RELEASE_INDEX_PATH="$release_index"
+  export NODE_RELEASE_INDEX_URL="$base_url/release-index"
+  export DOCKER_HUB_API_URL="$base_url/repositories"
+  export PYPI_API_URL="$base_url/pypi"
+  export DISCOVERY_REPORT_PATH="$report"
+  for setting in "$@"; do
+    export "${setting?}"
+  done
+  "$DISCOVERY_SCRIPT" "$mode"
+)
+
+# shellcheck disable=SC2031
+test_discovery_dry_run_and_apply() {
+  local dry_run_output
+
+  dry_run_output="$(run_discovery --dry-run)"
+  [[ ! -e "$report" ]]
+  assert_json "$dry_run_output" '.dryRun == true'
+  assert_json "$dry_run_output" '.changes.secrets | length == 3'
+  assert_json "$dry_run_output" '.changes.security | length == 3'
+  assert_json "$dry_run_output" '.changes.secrets[] | select(.major == 22 and .classification == "patch")'
+  assert_json "$dry_run_output" '.changes.secrets[] | select(.major == 24 and .classification == "minor")'
+  assert_json "$dry_run_output" '.changes.secrets[] | select(.major == 26 and .classification == "new-major")'
+  assert_json "$dry_run_output" '.changes.security[] | select(.major == 22) | .toolChanges[] | select(.variable == "SEMGREP_VERSION" and .selected == "1.50.1")'
+
+  run_discovery --apply >/dev/null
+  assert_json "$(<"$report")" '.dryRun == false'
+  assert_env_value "$root/node/secrets/22" NODE_VERSION 22.1.1
+  assert_env_value "$root/node/secrets/24" INFISICAL_VERSION 0.21.0
+  assert_env_value "$root/node/secrets/26" NODE_VERSION 26.0.0
+  assert_env_value "$root/node/security/22" SEMGREP_VERSION 1.50.1
+  assert_env_value "$root/node/security/26" NODE_VERSION 26.0.0
+}
+
+# shellcheck disable=SC2031
+test_discovery_write_failure() {
+  expect_failure "Discovery report write failure" "EISDIR" \
+    run_discovery --apply "DISCOVERY_REPORT_PATH=$tmp"
+}
+
+test_discovery_configuration() {
+  # shellcheck disable=SC2016 # $1 and $2 are expanded by the child Bash process.
+  expect_failure "Discovery without report path" "DISCOVERY_REPORT_PATH is required" \
+    env -u DISCOVERY_REPORT_PATH bash -c 'cd "$1" && "$2" --apply' _ "$REPO_ROOT" "$DISCOVERY_SCRIPT"
+}
+
+write_publisher_report() {
+  local mode="$1" path="$2" version="$3"
+
+  jq -n --arg mode "$mode" --arg path "$path" --arg version "$version" '
+    {dryRun: false, generatedAt: "2026-07-16T00:00:00Z", changes: {secrets: [], security: []}, skipped: []}
+    | .changes[$mode] = [{path: $path, major: ($path | split("/") | last | tonumber), currentNodeVersion: "old", latestNodeVersion: $version, classification: "patch", toolChanges: []}]
+  '
+}
+
+write_noop_report() {
+  printf '%s\n' '{"dryRun":false,"generatedAt":"2026-07-16T00:00:00Z","changes":{"secrets":[],"security":[]},"skipped":[]}' >"$1"
+}
+
+run_publisher_configuration_and_noop_tests() (
+  local tmp report mode output
+
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  report="$tmp/report.json"
+  for mode in secrets security; do
+    expect_failure "Publisher $mode without report path" "DISCOVERY_REPORT_PATH is required" \
+      env -u DISCOVERY_REPORT_PATH "$PUBLISHER_SCRIPT" "$mode"
+  done
+  expect_failure "Publisher with an unknown mode" "Unknown publisher mode: invalid" \
+    "$PUBLISHER_SCRIPT" invalid
+
+  write_noop_report "$report"
+  for mode in secrets security; do
+    output="$(cd "$REPO_ROOT" && DISCOVERY_REPORT_PATH="$report" "$PUBLISHER_SCRIPT" "$mode")"
+    [[ "$output" == "No node-$mode changes to publish." ]]
+  done
+)
+
+run_publisher_tests() (
+  local tmp report log mode path version output worktree
+
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  log="$tmp/commands.log"
+  cat >"$tmp/git" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${MOCK_COMMAND_LOG:?}"
+args=("$@")
+while [[ "${args[0]:-}" == -C ]]; do args=("${args[@]:2}"); done
+case "${args[0]:-}" in
+  config) [[ "${args[1]:-}" == user.name ]] && printf 'Test User\n' || printf 'test@example.com\n' ;;
+  status) printf ' M %s\n' "${MOCK_CHANGED_PATH:?}" ;;
+  ls-remote) printf 'expected-sha\trefs/heads/%s\n' "${MOCK_BRANCH:?}" ;;
+  worktree)
+    if [[ "${args[1]:-}" == add ]]; then
+      printf '%s\n' "${args[5]:?}" >"${MOCK_WORKTREE_PATH:?}"
+      mkdir -p "${args[5]:?}"
+    else
+      rm -rf "${args[3]:?}"
+    fi
+    ;;
+  diff)
+    if [[ "${MOCK_STAGED:-true}" == true ]]; then
+      printf '%s\n' "${MOCK_CHANGED_PATH:?}"
+    fi
+    ;;
+  fetch|add|commit|push) ;;
+esac
+SH
+  cat >"$tmp/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${MOCK_COMMAND_LOG:?}"
+pr='{"number":42,"url":"https://example.test/pr/42","isDraft":false,"body":"","headRefOid":"test-sha"}'
+case "$1 $2" in
+  "auth status"|"pr ready") ;;
+  "pr list") [[ "${MOCK_EXISTING_PR:-true}" == true ]] && printf '%s\n' "$pr" ;;
+  "pr view") printf '%s\n' "$pr" ;;
+  "pr edit")
+    for ((index = 1; index <= $#; index++)); do
+      [[ "${!index}" == --body-file ]] || continue
+      next_index=$((index + 1))
+      [[ -s "${!next_index}" ]]
+    done
+    ;;
+  *) printf 'unexpected gh args: %s\n' "$*" >&2; exit 1 ;;
+esac
+SH
+  chmod +x "$tmp/git" "$tmp/gh"
+
+  for mode in secrets security; do
+    case "$mode" in
+      secrets) path=node/secrets/22; version=22.22.1 ;;
+      security) path=node/security/24; version=24.14.0 ;;
+    esac
+    report="$tmp/$mode-report.json"
+    write_publisher_report "$mode" "$path" "$version" >"$report"
+    mkdir -p "$tmp/repo/$(dirname "$path")"
+    printf 'NODE_VERSION=old\n' >"$tmp/repo/$path"
+    : >"$log"
+    output="$(
+      cd "$tmp/repo"
+      PATH="$tmp:$PATH" MOCK_COMMAND_LOG="$log" MOCK_CHANGED_PATH="$path" \
+        MOCK_BRANCH="automation/node-$mode-updates" MOCK_WORKTREE_PATH="$tmp/worktree" \
+        DISCOVERY_REPORT_PATH="$report" "$PUBLISHER_SCRIPT" "$mode"
+    )"
+    [[ "$output" == "Published node-$mode update PR." ]]
+    grep -Fq "worktree add --force -B automation/node-$mode-updates" "$log"
+    grep -Fq "push --force-with-lease=refs/heads/automation/node-$mode-updates:expected-sha origin automation/node-$mode-updates:automation/node-$mode-updates" "$log"
+    grep -Fq "worktree remove --force" "$log"
+    worktree="$(<"$tmp/worktree")"
+    [[ ! -e "$worktree" ]]
+    grep -Fq "pr edit 42 --title feat: \`node-$mode\` $version" "$log"
+    if [[ "$mode" == security ]]; then
+      grep -Fqx 'pr ready 42 --undo' "$log"
+    fi
+  done
+
+  mode=secrets
+  path=node/secrets/22
+  version=22.22.1
+  report="$tmp/refresh-report.json"
+  write_publisher_report "$mode" "$path" "$version" >"$report"
+  : >"$log"
+  output="$(
+    cd "$tmp/repo"
+    PATH="$tmp:$PATH" MOCK_COMMAND_LOG="$log" MOCK_CHANGED_PATH="$path" \
+      MOCK_BRANCH="automation/node-secrets-updates" MOCK_WORKTREE_PATH="$tmp/refresh-worktree" \
+      MOCK_STAGED=false MOCK_EXISTING_PR=true DISCOVERY_REPORT_PATH="$report" \
+      "$PUBLISHER_SCRIPT" "$mode"
+  )"
+  [[ "$output" == 'Refreshed existing node-secrets update PR; no new commit was needed.' ]]
+  # shellcheck disable=SC2016 # Backticks are literal markdown in the expected PR title.
+  grep -Fq 'pr edit 42 --title feat: `node-secrets` 22.22.1 --body-file' "$log"
+  if grep -Fq 'commit -m' "$log"; then
+    printf 'Publisher unexpectedly committed during a refresh.\n' >&2
+    return 1
+  fi
+  if grep -Fq 'push --force-with-lease' "$log"; then
+    printf 'Publisher unexpectedly pushed during a refresh.\n' >&2
+    return 1
+  fi
+  worktree="$(<"$tmp/refresh-worktree")"
+  [[ ! -e "$worktree" ]]
+
+  : >"$log"
+  cat >"$tmp/cp" <<'SH'
+#!/usr/bin/env sh
+printf 'simulated copy failure\n' >&2
+exit 1
+SH
+  chmod +x "$tmp/cp"
+  # shellcheck disable=SC2016 # The child Bash process expands its positional parameters and environment.
+  expect_failure "Publisher copy failure" "simulated copy failure" bash -c '
+    cd "$1"
+    PATH="$2:$PATH" MOCK_COMMAND_LOG="$3" MOCK_CHANGED_PATH="$4" \
+      MOCK_BRANCH=automation/node-secrets-updates MOCK_WORKTREE_PATH="$5" \
+      DISCOVERY_REPORT_PATH="$6" "$7" secrets
+  ' _ "$tmp/repo" "$tmp" "$log" "$path" "$tmp/failure-worktree" "$report" "$PUBLISHER_SCRIPT"
+  grep -Fq 'worktree remove --force' "$log"
+  worktree="$(<"$tmp/failure-worktree")"
+  [[ ! -e "$worktree" ]]
+)
+
+# PATH mutation is isolated to this test subshell.
+# shellcheck disable=SC2030,SC2031
+run_gate_test() (
+  local docker_status="$1" is_draft="$2" expected_text="$3" expected_ready_args="$4"
+  local tmp output
+
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  printf 'Existing body\n' >"$tmp/pr-body.md"
+  cat >"$tmp/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${MOCK_GH_LOG:?}"; body_file="${MOCK_PR_BODY_FILE:?}"
+body="$(jq -Rs . <"$body_file")"
+pr="{\"number\":42,\"url\":\"https://example.test/pr/42\",\"isDraft\":${MOCK_PR_IS_DRAFT:?},\"body\":$body,\"headRefOid\":\"raw-content-sha\"}"
+case "$1 $2" in
+  "auth status") ;;
+  "pr list") printf '%s\n' "$pr" ;;
+  "pr view")
+    if [[ " $* " == *" --json files "* ]]; then printf 'node/security/24\n'; else printf '%s\n' "$pr"; fi
+    ;;
+  "repo view") printf 'studiondev/pipeline-images\n' ;;
+  "api -H") printf 'NODE_VERSION=24.14.0\nSEMGREP_VERSION=1.51.0\n' ;;
+  "pr edit")
+    [[ "$3" == 42 && "$4" == --body ]]
+    printf '%s' "$5" >"$body_file"
+    printf '%s\n' "$*" >>"$log"
+    ;;
+  "pr ready") printf '%s\n' "$*" >>"$log" ;;
+  *) printf 'unexpected gh args: %s\n' "$*" >&2; exit 1 ;;
+esac
+SH
+  cat >"$tmp/curl" <<'SH'
+#!/usr/bin/env sh
+printf '%s' "${MOCK_DOCKER_STATUS:?}"
+SH
+  chmod +x "$tmp/gh" "$tmp/curl"
+
+  run_gate() (
+    cd "$REPO_ROOT"
+    PATH="$tmp:$PATH" MOCK_GH_LOG="$tmp/gh.log" MOCK_PR_BODY_FILE="$tmp/pr-body.md" \
+      MOCK_PR_IS_DRAFT="$is_draft" MOCK_DOCKER_STATUS="$docker_status" \
+      "$SCRIPT_DIR/update-security-pr-gate.sh"
+  )
+
+  if [[ "$expected_text" == error ]]; then
+    expect_failure "Gate error response" "Docker tag check failed (500)" run_gate
+    return
+  fi
+
+  output="$(run_gate)"
+  [[ "$output" == "Security dependency gate: $expected_text." ]]
+  output="$(run_gate)"
+  [[ "$output" == "Security dependency gate: $expected_text." ]]
+  grep -Fqx "$expected_ready_args" "$tmp/gh.log"
+  [[ "$(grep -Fxc '<!-- node-security-dependency-gate:start -->' "$tmp/pr-body.md")" == 1 ]]
+  [[ "$(grep -Fxc '<!-- node-security-dependency-gate:end -->' "$tmp/pr-body.md")" == 1 ]]
+  grep -Fqx 'Existing body' "$tmp/pr-body.md"
+)
+
+run_cli_diagnostic_test() {
+  expect_failure "Discovery without arguments" "'--apply' or '--dry-run'" "$DISCOVERY_SCRIPT"
+}
+
+main() {
+  run_static_checks
+  with_discovery_fixture test_discovery_dry_run_and_apply
+  with_discovery_fixture test_discovery_write_failure
+  test_discovery_configuration
+  run_cli_diagnostic_test
+  run_publisher_configuration_and_noop_tests
+  run_publisher_tests
+  run_gate_test 200 true ready 'pr ready 42'
+  run_gate_test 404 false blocked 'pr ready 42 --undo'
+  run_gate_test 500 true error ''
+  printf 'Update automation validation passed.\n'
+}
+
+main "$@"


### PR DESCRIPTION
Add a scheduled weekly CircleCI job that detects new even Node.js releases. When new versions are found, the job creates or updates the corresponding image env files and pushes the changes to a feature branch, automatically opening a PR. The job also updates the image related tools to the appropriate versions.