### PR TITLE
fix: correct user email for Node image updates git config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: Configure Git
           command: |
             git config user.name "studion-images[bot]"
-            git config user.email "4314765+studion-images[bot]@users.noreply.github.com"
+            git config user.email "305842011+studion-images[bot]@users.noreply.github.com"
             git config --global --unset-all url."ssh://git@github.com/".insteadOf 2>/dev/null || true
             git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
             git config --global url."https://github.com/".insteadOf "git@github.com:"


### PR DESCRIPTION
Previously GitHub App ID was used as a first part, i.e. before the `+` sign, but it should have been the user ID associated with the app.