### PR TITLE
fix: run security gate after image matrix

### DIFF
--- a/.circleci/push-image.yml
+++ b/.circleci/push-image.yml
@@ -65,4 +65,6 @@ workflows:
             alias: write-build-push
             parameters:
               env_file_path: []
-      - update-security-pr-gate
+      - update-security-pr-gate:
+          requires:
+            - write-build-push

--- a/scripts/detect-image-changes.sh
+++ b/scripts/detect-image-changes.sh
@@ -2,7 +2,6 @@
 
 CONTINUE_CONFIG_PATH=".circleci/push-image.yml"
 CHANGES_PARAM_KEY=".workflows.push-image-to-hub.jobs[0].write-build-push.matrix.parameters.env_file_path"
-GATE_REQUIRES_KEY=".workflows.push-image-to-hub.jobs[1].update-security-pr-gate.requires"
 DIFF_JSON_ARR=$(git diff --name-only --diff-filter=AM HEAD~1 |
   grep -E '^node/(secrets|security)/[0-9]+$' |
   jq -R -c -s 'split("\n")[:-1]')
@@ -23,6 +22,5 @@ fi
 echo "Detected image changes: ${DIFF_JSON_ARR}"
 
 yq "${CHANGES_PARAM_KEY}=${DIFF_JSON_ARR}" -i "${CONTINUE_CONFIG_PATH}"
-yq "${GATE_REQUIRES_KEY}=[\"write-build-push\"]" -i "${CONTINUE_CONFIG_PATH}"
 
 echo "Updated ${CONTINUE_CONFIG_PATH} with image changes"


### PR DESCRIPTION
Drop non-working dynamic requires mutation and statically define the requires stanza in the image continuation workflow for the `update-security-pr-gate` job ensuring it runs only after all image `build-and-push` matrix jobs.